### PR TITLE
Fixed hook_help() parameters.

### DIFF
--- a/profile2.module
+++ b/profile2.module
@@ -17,7 +17,7 @@ use Symfony\Component\HttpFoundation\Request;
 /**
  * Implements hook_help().
  */
-function profile2_help($route_name, Request $request) {
+function profile2_help($route_name, \Drupal\Core\Routing\RouteMatchInterface $route_match) {
   switch ($route_name) {
     case 'help.page.profile2':
 //      @todo:


### PR DESCRIPTION
Wrong params for hook_help -- crashes Drupal on module install.
