### PR TITLE
DrupalUnitTestBase renamed to KernelTestBase

### DIFF
--- a/src/Tests/ProfileCRUDTest.php
+++ b/src/Tests/ProfileCRUDTest.php
@@ -7,12 +7,12 @@
 
 namespace Drupal\profile\Tests;
 
-use Drupal\simpletest\DrupalUnitTestBase;
+use Drupal\simpletest\KernelTestBase;
 
 /**
  * Tests basic CRUD functionality of profiles.
  */
-class ProfileCRUDTest extends DrupalUnitTestBase {
+class ProfileCRUDTest extends KernelTestBase {
 
   public static $modules = array('system', 'field', 'field_sql_storage', 'user', 'profile');
 


### PR DESCRIPTION
Rename DrupalUnitTestBase to KernelTestBase following https://www.drupal.org/node/2271271
