### PR TITLE
D8beta4 tests fix

### DIFF
--- a/config/install/system.action.profile_delete_action.yml
+++ b/config/install/system.action.profile_delete_action.yml
@@ -7,4 +7,3 @@ id: profile_delete_action
 label: 'Delete selected profile'
 type: profile
 plugin: profile_delete_action
-configuration: {  }

--- a/config/install/system.action.profile_publish_action.yml
+++ b/config/install/system.action.profile_publish_action.yml
@@ -7,4 +7,3 @@ id: profile_publish_action
 label: 'Publish selected profile'
 type: profile
 plugin: profile_publish_action
-configuration: {  }

--- a/config/install/system.action.profile_unpublish_action.yml
+++ b/config/install/system.action.profile_unpublish_action.yml
@@ -7,4 +7,3 @@ id: profile_unpublish_action
 label: 'Unublish selected profile'
 type: profile
 plugin: profile_unpublish_action
-configuration: {  }

--- a/config/schema/profile.schema.yml
+++ b/config/schema/profile.schema.yml
@@ -26,3 +26,15 @@ profile.type.*:
     langcode:
       type: string
       label: 'Default language'
+
+action.configuration.profile_delete_action:
+  type: action_configuration_default
+  label: 'Delete profile configuration'
+
+action.configuration.profile_publish_action:
+  type: action_configuration_default
+  label: 'Publish selected profile configuration'
+
+action.configuration.profile_unpublish_action:
+  type: action_configuration_default
+  label: 'Unpublish selected profile configuration'

--- a/src/Tests/ProfileAccessTest.php
+++ b/src/Tests/ProfileAccessTest.php
@@ -8,6 +8,8 @@
 namespace Drupal\profile\Tests;
 
 use Drupal\simpletest\WebTestBase;
+use Drupal\field\Entity\FieldStorageConfig;
+use Drupal\field\Entity\FieldConfig;
 
 /**
  * Tests profile access handling.
@@ -30,23 +32,28 @@ class ProfileAccessTest extends WebTestBase {
 
     $this->field = array(
       'field_name' => 'profile_fullname',
+      'entity_type' => 'profile',
       'type' => 'text',
       'cardinality' => 1,
       'translatable' => FALSE,
     );
-    $this->field = field_create_field($this->field);
+    $this->field = FieldStorageConfig::create($this->field);
+    $this->field->save();
+
     $this->instance = array(
-      'entity_type' => 'profile',
-      'field_name' => $this->field['field_name'],
+      'entity_type' => $this->field->entity_type,
+      'field_name' => $this->field->field_name,
       'bundle' => $this->type->id(),
       'label' => 'Full name',
       'widget' => array(
         'type' => 'text_textfield',
       ),
     );
-    $this->instance = field_create_instance($this->instance);
+    $this->instance = FieldConfig::create($this->instance);
+    $this->instance->save();
+
     $this->display = entity_get_display('profile', 'test', 'default')
-      ->setComponent($this->field['field_name'], array(
+      ->setComponent($this->field->field_name, array(
         'type' => 'text_default',
       ));
     $this->display->save();
@@ -67,7 +74,7 @@ class ProfileAccessTest extends WebTestBase {
    */
   function testAdminOnlyProfiles() {
     $id = $this->type->id();
-    $field_name = $this->field['field_name'];
+    $field_name = $this->field->field_name;
 
     // Create a test user account.
     $web_user = $this->drupalCreateUser(array('access user profiles'));

--- a/src/Tests/ProfileAccessTest.php
+++ b/src/Tests/ProfileAccessTest.php
@@ -72,7 +72,7 @@ class ProfileAccessTest extends WebTestBase {
     // Create a test user account.
     $web_user = $this->drupalCreateUser(array('access user profiles'));
     $uid = $web_user->id();
-    $value = $this->randomName();
+    $value = $this->randomMachineName();
 
     // Administratively enter profile field values for the new account.
     $this->drupalLogin($this->admin_user);
@@ -98,7 +98,7 @@ class ProfileAccessTest extends WebTestBase {
     user_role_grant_permissions(DRUPAL_AUTHENTICATED_RID, array("edit own $id profile"));
 
     // Verify that the user is able to edit the own profile.
-    $value = $this->randomName();
+    $value = $this->randomMachineName();
     $edit = array(
       "{$field_name}[und][0][value]" => $value,
     );

--- a/src/Tests/ProfileAccessTest.php
+++ b/src/Tests/ProfileAccessTest.php
@@ -11,18 +11,12 @@ use Drupal\simpletest\WebTestBase;
 
 /**
  * Tests profile access handling.
+ *
+ * @group profile
  */
 class ProfileAccessTest extends WebTestBase {
 
   public static $modules = array('profile', 'text');
-
-  public static function getInfo() {
-    return array(
-      'name' => 'Profile access',
-      'description' => 'Tests profile access handling.',
-      'group' => 'profile',
-    );
-  }
 
   function setUp() {
     parent::setUp();

--- a/src/Tests/ProfileAttachTest.php
+++ b/src/Tests/ProfileAttachTest.php
@@ -72,7 +72,7 @@ class ProfileAttachTest extends WebTestBase {
 
     // Allow registration without administrative approval and log in user
     // directly after registering.
-    config('user.settings')
+    \Drupal::config('user.settings')
       ->set('register', USER_REGISTER_VISITORS)
       ->set('verify_mail', 0)
       ->save();

--- a/src/Tests/ProfileAttachTest.php
+++ b/src/Tests/ProfileAttachTest.php
@@ -8,6 +8,8 @@
 namespace Drupal\profile\Tests;
 
 use Drupal\simpletest\WebTestBase;
+use Drupal\field\Entity\FieldStorageConfig;
+use Drupal\field\Entity\FieldConfig;
 
 /**
  * Tests attaching of profile entity forms to other forms.
@@ -32,13 +34,16 @@ class ProfileAttachTest extends WebTestBase {
     $this->field = array(
       'field_name' => 'profile_fullname',
       'type' => 'text',
+      'entity_type' => 'profile',
       'cardinality' => 1,
       'translatable' => FALSE,
     );
-    $this->field = field_create_field($this->field);
+    $this->field = FieldStorageConfig::create($this->field);
+    $this->field->save();
+
     $this->instance = array(
-      'entity_type' => 'profile',
-      'field_name' => $this->field['field_name'],
+      'entity_type' => $this->field->entity_type,
+      'field_name' => $this->field->field_name,
       'bundle' => $this->type->id(),
       'label' => 'Full name',
       'required' => TRUE,
@@ -46,9 +51,11 @@ class ProfileAttachTest extends WebTestBase {
         'type' => 'text_textfield',
       ),
     );
-    $this->instance = field_create_instance($this->instance);
+    $this->instance = FieldConfig::create($this->instance);
+    $this->instance->save();
+
     $this->display = entity_get_display('profile', 'test', 'default')
-      ->setComponent($this->field['field_name'], array(
+      ->setComponent($this->field->field_name, array(
         'type' => 'text_default',
       ));
     $this->display->save();
@@ -61,7 +68,7 @@ class ProfileAttachTest extends WebTestBase {
    */
   function testUserRegisterForm() {
     $id = $this->type->id();
-    $field_name = $this->field['field_name'];
+    $field_name = $this->field->field_name;
 
     // Allow registration without administrative approval and log in user
     // directly after registering.
@@ -81,7 +88,7 @@ class ProfileAttachTest extends WebTestBase {
       'pass[pass2]' => $pass_raw,
     );
     $this->drupalPost('user/register', $edit, t('Create new account'));
-    $this->assertRaw(t('@name field is required.', array('@name' => $this->instance['label'])));
+    $this->assertRaw(t('@name field is required.', array('@name' => $this->instance->label)));
 
     // Verify that we can register.
     $edit["profile[$id][$field_name][und][0][value]"] = $this->randomMachineName();

--- a/src/Tests/ProfileAttachTest.php
+++ b/src/Tests/ProfileAttachTest.php
@@ -72,11 +72,11 @@ class ProfileAttachTest extends WebTestBase {
     user_role_grant_permissions(DRUPAL_AUTHENTICATED_RID, array('view own test profile'));
 
     // Verify that the additional profile field is attached and required.
-    $name = $this->randomName();
-    $pass_raw = $this->randomName();
+    $name = $this->randomMachineName();
+    $pass_raw = $this->randomMachineName();
     $edit = array(
       'name' => $name,
-      'mail' => $this->randomName() . '@example.com',
+      'mail' => $this->randomMachineName() . '@example.com',
       'pass[pass1]' => $pass_raw,
       'pass[pass2]' => $pass_raw,
     );
@@ -84,7 +84,7 @@ class ProfileAttachTest extends WebTestBase {
     $this->assertRaw(t('@name field is required.', array('@name' => $this->instance['label'])));
 
     // Verify that we can register.
-    $edit["profile[$id][$field_name][und][0][value]"] = $this->randomName();
+    $edit["profile[$id][$field_name][und][0][value]"] = $this->randomMachineName();
     $this->drupalPost(NULL, $edit, t('Create new account'));
     $this->assertText(t('Registration successful. You are now logged in.'));
 

--- a/src/Tests/ProfileAttachTest.php
+++ b/src/Tests/ProfileAttachTest.php
@@ -11,18 +11,12 @@ use Drupal\simpletest\WebTestBase;
 
 /**
  * Tests attaching of profile entity forms to other forms.
+ *
+ * @group profile
  */
 class ProfileAttachTest extends WebTestBase {
 
   public static $modules = array('profile', 'text');
-
-  public static function getInfo() {
-    return array(
-      'name' => 'Profile form attachment',
-      'description' => 'Tests attaching of profile entity forms to other forms.',
-      'group' => 'profile',
-    );
-  }
 
   function setUp() {
     parent::setUp();

--- a/src/Tests/ProfileCRUDTest.php
+++ b/src/Tests/ProfileCRUDTest.php
@@ -11,18 +11,12 @@ use Drupal\simpletest\KernelTestBase;
 
 /**
  * Tests basic CRUD functionality of profiles.
+ *
+ * @group profile
  */
 class ProfileCRUDTest extends KernelTestBase {
 
   public static $modules = array('system', 'field', 'field_sql_storage', 'user', 'profile');
-
-  public static function getInfo() {
-    return array(
-      'name' => 'Profile CRUD operations',
-      'description' => 'Tests basic CRUD functionality of profiles.',
-      'group' => 'profile',
-    );
-  }
 
   function setUp() {
     parent::setUp();

--- a/src/Tests/ProfileCRUDTest.php
+++ b/src/Tests/ProfileCRUDTest.php
@@ -30,21 +30,21 @@ class ProfileCRUDTest extends KernelTestBase {
    */
   function testCRUD() {
     $types_data = array(
-      0 => array('label' => $this->randomName()),
-      1 => array('label' => $this->randomName()),
+      0 => array('label' => $this->randomMachineName()),
+      1 => array('label' => $this->randomMachineName()),
     );
     foreach ($types_data as $id => $values) {
       $types[$id] = entity_create('profile_type', array('id' => $id) + $values);
       $types[$id]->save();
     }
     $this->user1 = entity_create('user', array(
-      'name' => $this->randomName(),
-      'mail' => $this->randomName() . '@example.com',
+      'name' => $this->randomMachineName(),
+      'mail' => $this->randomMachineName() . '@example.com',
     ));
     $this->user1->save();
     $this->user2 = entity_create('user', array(
-      'name' => $this->randomName(),
-      'mail' => $this->randomName() . '@example.com',
+      'name' => $this->randomMachineName(),
+      'mail' => $this->randomMachineName() . '@example.com',
     ));
     $this->user2->save();
 

--- a/src/Tests/ProfileCRUDTest.php
+++ b/src/Tests/ProfileCRUDTest.php
@@ -7,12 +7,12 @@
 
 namespace Drupal\profile\Tests;
 
-use Drupal\simpletest\DrupalUnitTestBase;
+use Drupal\simpletest\KernelTestBase;
 
 /**
  * Tests basic CRUD functionality of profiles.
  */
-class ProfileCRUDTest extends DrupalUnitTestBase {
+class ProfileCRUDTest extends KernelTestBase {
 
   public static $modules = array('system', 'field', 'field_sql_storage', 'user', 'profile');
 

--- a/src/Tests/ProfileFieldAccessTest.php
+++ b/src/Tests/ProfileFieldAccessTest.php
@@ -73,7 +73,7 @@ class ProfileFieldAccessTest extends WebTestBase {
     // Fill in a field value.
     $this->drupalLogin($this->web_user);
     $uid = $this->web_user->id();
-    $secret = $this->randomName();
+    $secret = $this->randomMachineName();
     $edit = array(
       'field_secret[und][0][value]' => $secret,
     );

--- a/src/Tests/ProfileFieldAccessTest.php
+++ b/src/Tests/ProfileFieldAccessTest.php
@@ -11,18 +11,12 @@ use Drupal\simpletest\WebTestBase;
 
 /**
  * Tests profile field access functionality.
+ *
+ * @group profile
  */
 class ProfileFieldAccessTest extends WebTestBase {
 
   public static $modules = array('profile', 'text', 'field_ui');
-
-  public static function getInfo() {
-    return array(
-      'name' => 'Field access',
-      'description' => 'Tests profile field access functionality.',
-      'group' => 'profile',
-    );
-  }
 
   function setUp() {
     parent::setUp();

--- a/src/Tests/ProfileTypeCRUDTest.php
+++ b/src/Tests/ProfileTypeCRUDTest.php
@@ -11,18 +11,12 @@ use Drupal\simpletest\WebTestBase;
 
 /**
  * Tests basic CRUD functionality of profile types.
+ *
+ * @group profile
  */
 class ProfileTypeCRUDTest extends WebTestBase {
 
   public static $modules = array('profile', 'field_ui', 'text');
-
-  public static function getInfo() {
-    return array(
-      'name' => 'Profile type CRUD operations',
-      'description' => 'Tests basic CRUD functionality of profile types.',
-      'group' => 'profile',
-    );
-  }
 
   /**
    * Tests CRUD operations for profile types through the UI.

--- a/src/Tests/ProfileTypeCRUDTest.php
+++ b/src/Tests/ProfileTypeCRUDTest.php
@@ -28,7 +28,7 @@ class ProfileTypeCRUDTest extends WebTestBase {
     $this->drupalGet('admin/people/profiles');
     $this->clickLink(t('Add profile type'));
     $this->assertUrl('admin/people/profiles/add');
-    $id = drupal_strtolower($this->randomName());
+    $id = drupal_strtolower($this->randomMachineName());
     $label = $this->randomString();
     $edit = array(
       'id' => $id,
@@ -54,7 +54,7 @@ class ProfileTypeCRUDTest extends WebTestBase {
 
     // Add a field to the profile type.
     $this->drupalGet("admin/people/profiles/manage/$id/fields");
-    $field_name = drupal_strtolower($this->randomName());
+    $field_name = drupal_strtolower($this->randomMachineName());
     $field_label = $this->randomString();
     $edit = array(
       'fields[_add_new_field][label]' => $field_name,
@@ -69,7 +69,7 @@ class ProfileTypeCRUDTest extends WebTestBase {
 
     // Rename the profile type ID.
     $this->drupalGet("admin/people/profiles/manage/$id/edit");
-    $new_id = drupal_strtolower($this->randomName());
+    $new_id = drupal_strtolower($this->randomMachineName());
     $edit = array(
       'id' => $new_id,
     );


### PR DESCRIPTION
Embed multiples fixs for simpletest and tests.
One pull request to rule them all. I close previous.
- Rename DrupalUnitTestBase to KernelTestBase following https://www.drupal.org/node/2271271
- Test class getInfo() removed. See https://www.drupal.org/node/2301125 for more details.
- #2315865 Rename randomName() called function to randomMachineName(). See issue on https://www.drupal.org/node/2315865 for more details.
- Set action configuration for delete, publish and unpublish actions in profile.schema.yml file.

Tests failed. Based on error message and node module, fix this adding action configuration data in profile.schema.yml like :

```
action.configuration.profile_delete_action:
  type: action_configuration_default
  label: 'Delete profile configuration'
```
- #2012896 fields are now configuration entities. Field and field instance are now configuration entities.

Use FieldStorageConfig::create() instead of field_create_field().
Use FieldConfig::create() instead of field_create_instance().

See details on https://www.drupal.org/node/2012896
- Global config function no more exists. config() fonction is called instead of \Drupal::config().
