### PR TITLE
D8 commit 02d58f6

### DIFF
--- a/config/schema/profile.schema.yml
+++ b/config/schema/profile.schema.yml
@@ -1,5 +1,5 @@
 profile.type.*:
-  type: mapping
+  type: config_entity
   label: 'Profile type settings'
   mapping:
     id:

--- a/profile.links.action.yml
+++ b/profile.links.action.yml
@@ -1,5 +1,5 @@
 profile_type_add:
-  route_name: profile.type_add
+  route_name: entity.profile_type.add_form
   title: 'Add profile type'
   appears_on:
     - profile.overview_types

--- a/profile.module
+++ b/profile.module
@@ -245,14 +245,14 @@ function template_preprocess_profile_items(&$variables) {
       if ($profile_item->access('update')) {
         $variables['edit_links'][] = \Drupal::l(t('Edit'), new Url("entity.profile.edit_form", array(
           'user' => \Drupal::currentUser()->id(),
-          'type' => $profile_item->bundle(),
+          'profile_type' => $profile_item->bundle(),
           'profile' => $profile_item->id(),
         )));
       }
       if ($profile_item->access('delete')) {
         $variables['delete_links'][] = \Drupal::l(t('Delete'), new Url("entity.profile.delete_form", array(
           'user' => \Drupal::currentUser()->id(),
-          'type' => $profile_item->bundle(),
+          'profile_type' => $profile_item->bundle(),
           'profile' => $profile_item->id(),
         )));
       }

--- a/profile.routing.yml
+++ b/profile.routing.yml
@@ -13,7 +13,7 @@ profile.overview_types:
   requirements:
     _permission: 'administer profile types'
 
-profile.type_add:
+entity.profile_type.add_form:
   path: '/admin/config/people/profiles/types/add'
   defaults:
     _entity_form: 'profile_type.add'
@@ -21,7 +21,7 @@ profile.type_add:
   requirements:
     _permission: 'administer profile types'
 
-profile.type_edit:
+entity.profile_type.edit_form:
   path: '/admin/config/people/profiles/types/manage/{profile_type}'
   defaults:
     _entity_form: 'profile_type.edit'
@@ -29,7 +29,7 @@ profile.type_edit:
   requirements:
     _permission: 'administer profile types'
 
-profile.type_delete:
+entity.profile_type.delete_form:
   path: '/admin/config/people/profiles/types/manage/{profile_type}/delete'
   defaults:
     _entity_form: 'profile_type.delete'

--- a/profile.routing.yml
+++ b/profile.routing.yml
@@ -42,6 +42,7 @@ entity.profile.add_form:
   defaults:
     _controller: '\Drupal\profile\Controller\ProfileController::addProfile'
     _title: 'Add new profile'
+    operation: 'add'
   options:
     parameters:
       profile_type:
@@ -52,10 +53,8 @@ entity.profile.add_form:
 entity.profile.edit_form:
   path: '/user/{user}/edit/profile/{profile_type}/{profile}'
   defaults:
-    _entity_form: 'profile.default'
+    _entity_form: 'profile.edit'
     _title: 'Edit a profile'
-  options:
-    _admin_route: TRUE
   requirements:
     _entity_access: 'profile.update'
 
@@ -66,8 +65,6 @@ entity.profile.delete_form:
     _title: 'Delete a profile'
   requirements:
     _entity_access: 'profile.delete'
-  options:
-    _admin_route: TRUE
 
 entity.profile.canonical:
   path: '/profile/{profile}'

--- a/profile.routing.yml
+++ b/profile.routing.yml
@@ -38,17 +38,19 @@ entity.profile_type.delete_form:
     _permission: 'administer profile types'
 
 entity.profile.add_form:
-  path: '/user/{user}/edit/{type}'
+  path: '/user/{user}/edit/profile/{profile_type}'
   defaults:
     _controller: '\Drupal\profile\Controller\ProfileController::addProfile'
     _title: 'Add new profile'
   options:
-    _admin_route: TRUE
+    parameters:
+      profile_type:
+        use_current_language: TRUE
   requirements:
-    _profile_access_check: 'TRUE'
+    _profile_access_check: 'profile:{profile_type}'
 
 entity.profile.edit_form:
-  path: '/user/{user}/edit/{type}/{profile}'
+  path: '/user/{user}/edit/profile/{profile_type}/{profile}'
   defaults:
     _entity_form: 'profile.default'
     _title: 'Edit a profile'

--- a/profile.services.yml
+++ b/profile.services.yml
@@ -1,6 +1,6 @@
 services:
   profile.profile_access_checker:
     class: Drupal\profile\Access\ProfileAccessCheck
-    arguments: ['@current_user']
+    arguments: ['@entity.manager', '@request_stack']
     tags:
       - { name: access_check, applies_to: _profile_access_check }

--- a/src/Controller/ProfileController.php
+++ b/src/Controller/ProfileController.php
@@ -32,7 +32,7 @@ class ProfileController extends ControllerBase {
     $profile = $this->entityManager()->getStorage('profile')->create(array(
       'uid' => $user,
       'type' => $config->get('id'),
-      'langcode' => $langcode ? $langcode : $this->languageManager()->getCurrentLanguage()->id,
+      'langcode' => $langcode ? $langcode : $this->languageManager()->getCurrentLanguage()->getId(),
     ));
 
     return $this->entityFormBuilder()->getForm($profile, 'add', array('uid' => $user, 'created' => REQUEST_TIME));

--- a/src/Controller/ProfileController.php
+++ b/src/Controller/ProfileController.php
@@ -8,34 +8,35 @@
 namespace Drupal\profile\Controller;
 
 use Drupal\Core\Controller\ControllerBase;
+use Drupal\Core\DependencyInjection\ContainerInjectionInterface;
 use Drupal\profile\ProfileTypeInterface;
 use Drupal\profile\Entity\Profile;
+use Drupal\user\UserInterface;
 
 /**
  * Returns responses for ProfileController routes.
  */
-class ProfileController extends ControllerBase {
+class ProfileController extends ControllerBase implements ContainerInjectionInterface {
 
   /**
    * Provides the profile submission form.
    *
-   * @param \Drupal\profile\ProfileTypeInterface $type
-   *   The profile type entity for the node.
+   * @param \Drupal\user\UserInterface $profile_type
+   *   The user account.
+   * @param \Drupal\profile\ProfileTypeInterface $profile_type
+   *   The profile type entity for the profile.
    *
    * @return array
    *   A profile submission form.
    */
-  public function addProfile($user, $type) {
-    $config = \Drupal::config('profile.type.' . $type);
-    $langcode = $config->get('langcode');
+  public function addProfile(UserInterface $user, ProfileTypeInterface $profile_type) {
 
     $profile = $this->entityManager()->getStorage('profile')->create(array(
-      'uid' => $user,
-      'type' => $config->get('id'),
-      'langcode' => $langcode ? $langcode : $this->languageManager()->getCurrentLanguage()->getId(),
+      'uid' => $user->id(),
+      'type' => $profile_type->id(),
     ));
 
-    return $this->entityFormBuilder()->getForm($profile, 'add', array('uid' => $user, 'created' => REQUEST_TIME));
+    return $this->entityFormBuilder()->getForm($profile, 'add', array('uid' => $user->id(), 'created' => REQUEST_TIME));
   }
 
   /**

--- a/src/Entity/Profile.php
+++ b/src/Entity/Profile.php
@@ -33,7 +33,7 @@ use Drupal\user\UserInterface;
  *     },
  *   },
  *   bundle_entity_type = "profile_type",
- *   field_ui_base_route = "profile.type_edit",
+ *   field_ui_base_route = "entity.profile_type.edit_form",
  *   admin_permission = "administer profiles",
  *   base_table = "profile",
  *   data_table = "profile_field_data",
@@ -49,7 +49,7 @@ use Drupal\user\UserInterface;
  *   },
  *  links = {
  *    "canonical" = "entity.profile.canonical",
- *    "admin-form" = "profile.type_edit",
+ *    "admin-form" = "entity.profile_type.edit_form",
  *    "edit-form" = "entity.profile.edit_form",
  *    "delete-form" = "entity.profile.delete_form"
  *   },

--- a/src/Entity/Profile.php
+++ b/src/Entity/Profile.php
@@ -24,6 +24,7 @@ use Drupal\user\UserInterface;
  *   handlers = {
  *     "view_builder" = "Drupal\profile\ProfileViewBuilder",
  *     "views_data" = "Drupal\profile\ProfileViewsData",
+ *     "access" = "Drupal\profile\ProfileAccessControlHandler",
  *     "list_builder" = "Drupal\profile\ProfileListBuilder",
  *     "form" = {
  *       "default" = "Drupal\profile\ProfileFormController",

--- a/src/Entity/ProfileType.php
+++ b/src/Entity/ProfileType.php
@@ -34,10 +34,10 @@ use Drupal\profile\ProfileTypeInterface;
  *     "label" = "label"
  *   },
  *   links = {
- *     "add-form" = "profile.type_add",
- *     "delete-form" = "profile.type_delete",
- *     "edit-form" = "profile.type_edit",
- *     "admin-form" = "profile.type_edit",
+ *     "add-form" = "entity.profile_type.add_form",
+ *     "delete-form" = "entity.profile_type.delete_form",
+ *     "edit-form" = "entity.profile_type.edit_form",
+ *     "admin-form" = "entity.profile_type.edit_form",
  *   }
  * )
  */

--- a/src/ProfileAccessControlHandler.php
+++ b/src/ProfileAccessControlHandler.php
@@ -1,0 +1,126 @@
+<?php
+
+/**
+ * @file
+ * Contains \Drupal\profile\ProfileAccessControlHandler.
+ */
+
+namespace Drupal\profile;
+
+use Drupal\Core\Access\AccessResult;
+use Drupal\Core\Entity\EntityHandlerInterface;
+use Drupal\Core\Entity\EntityTypeInterface;
+use Drupal\Core\Field\FieldDefinitionInterface;
+use Drupal\Core\Field\FieldItemListInterface;
+use Drupal\Core\Language\LanguageInterface;
+use Drupal\Core\Entity\EntityAccessControlHandler;
+use Drupal\Core\Entity\EntityInterface;
+use Drupal\Core\Session\AccountInterface;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+/**
+ * Defines the access control handler for the profile entity type.
+ *
+ * @see \Drupal\profile\Entity\Profile
+ */
+class ProfileAccessControlHandler extends EntityAccessControlHandler implements EntityHandlerInterface {
+
+  /**
+   * Constructs a NodeAccessControlHandler object.
+   *
+   * @param \Drupal\Core\Entity\EntityTypeInterface $entity_type
+   *   The entity type definition.
+   */
+  public function __construct(EntityTypeInterface $entity_type) {
+    parent::__construct($entity_type);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function createInstance(ContainerInterface $container, EntityTypeInterface $entity_type) {
+    return new static(
+      $entity_type
+    );
+  }
+
+
+  /**
+   * {@inheritdoc}
+   */
+  public function access(EntityInterface $entity, $operation, $langcode = LanguageInterface::LANGCODE_DEFAULT, AccountInterface $account = NULL, $return_as_object = FALSE) {
+    $account = $this->prepareUser($account);
+
+    $user_page = \Drupal::request()->attributes->get('user');
+
+    // Some times, operation edit is called update.
+    // Use edit in any case.
+    if ($operation == 'update') {
+      $operation = 'edit';
+    }
+
+    if ($account->hasPermission('bypass profile access')) {
+      $result = AccessResult::allowed()->cachePerRole();
+      return $return_as_object ? $result : $result->isAllowed();
+    }
+    if (
+      (
+        $operation == 'add'
+        && (
+          (
+            $user_page->id() == $account->id()
+            && $account->hasPermission($operation . ' own ' . $entity->id() . ' profile')
+          )
+          || $account->hasPermission($operation . ' any ' . $entity->id() . ' profile')
+        )
+      ) || (
+        $operation != 'add'
+        && (
+          (
+            $entity->getOwnerId() == $account->id()
+            && $account->hasPermission($operation . ' own ' . $entity->getType() . ' profile')
+          )
+          || $account->hasPermission($operation . ' any ' . $entity->getType() . ' profile')
+        )
+      )
+    ){
+      $result = AccessResult::allowed()->cachePerRole();
+      return $return_as_object ? $result : $result->isAllowed();
+    }
+    else {
+      $result = AccessResult::forbidden()->cachePerRole();
+      return $return_as_object ? $result : $result->isAllowed();
+    }
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function createAccess($entity_bundle = NULL, AccountInterface $account = NULL, array $context = array(), $return_as_object = FALSE) {
+    $account = $this->prepareUser($account);
+
+    if ($account->hasPermission('bypass profile access')) {
+      $result = AccessResult::allowed()->cachePerRole();
+      return $return_as_object ? $result : $result->isAllowed();
+    }
+
+    $result = AccessResult::allowed()->cachePerRole();
+    return $return_as_object ? $result : $result->isAllowed();
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function checkAccess(EntityInterface $entity, $operation, $langcode, AccountInterface $account) {
+    // No opinion.
+    return AccessResult::neutral();
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function checkCreateAccess(AccountInterface $account, array $context, $entity_bundle = NULL) {
+    return AccessResult::allowedIf($account->hasPermission('add ' . $entity_bundle . ' content'))->cachePerRole();
+  }
+
+}

--- a/src/ProfileTypeFormController.php
+++ b/src/ProfileTypeFormController.php
@@ -109,7 +109,7 @@ class ProfileTypeFormController extends EntityForm {
    * {@inheritdoc}
    */
   public function delete(array $form, FormStateInterface $form_state) {
-    $form_state->setRedirect('profile.type_delete', array(
+    $form_state->setRedirect('entity.profile_type.delete_form', array(
       'profile_type' => $this->entity->id()
     ));
   }

--- a/src/Tests/ProfileAccessTest.php
+++ b/src/Tests/ProfileAccessTest.php
@@ -92,7 +92,7 @@ class ProfileAccessTest extends WebTestBase {
     $edit = array(
       "{$field_name}[0][value]" => $value,
     );
-    $this->drupalPostForm("user/$uid/edit/profile/$id", $edit, t('Save and make active'));
+    $this->drupalPostForm("user/$uid/edit/profile/$id", $edit, t('Save'));
 
     $profiles = entity_load_multiple_by_properties('profile', array(
       'uid' => $uid,

--- a/src/Tests/ProfileAccessTest.php
+++ b/src/Tests/ProfileAccessTest.php
@@ -92,12 +92,13 @@ class ProfileAccessTest extends WebTestBase {
     $edit = array(
       "{$field_name}[0][value]" => $value,
     );
-    $this->drupalPostForm("user/$uid/edit/$id", $edit, t('Save'));
+    $this->drupalPostForm("user/$uid/edit/profile/$id", $edit, t('Save and make active'));
 
     $profiles = entity_load_multiple_by_properties('profile', array(
       'uid' => $uid,
       'type' => $this->type->id(),
     ));
+
     $profile = reset($profiles);
     $profile_id = $profile->id();
 
@@ -112,13 +113,13 @@ class ProfileAccessTest extends WebTestBase {
     $this->drupalGet("user/$uid");
     $this->assertNoText($this->type->label());
     $this->assertNoText($value);
-    $this->drupalGet("user/$uid/edit/$id/$profile_id");
+    $this->drupalGet("user/$uid/edit/profile/$id/$profile_id");
     $this->assertResponse(403);
 
     // Check edit link isn't displayed.
-    $this->assertNoLinkByHref("user/$uid/edit/$id/$profile_id");
+    $this->assertNoLinkByHref("user/$uid/edit/profile/$id/$profile_id");
     // Check delete link isn't displayed.
-    $this->assertNoLinkByHref("user/$uid/delete/$id/$profile_id");
+    $this->assertNoLinkByHref("user/$uid/delete/profile/$id/$profile_id");
 
     // Allow users to edit own profiles.
     user_role_grant_permissions(DRUPAL_AUTHENTICATED_RID, array("edit own $id profile"));
@@ -128,7 +129,7 @@ class ProfileAccessTest extends WebTestBase {
     $edit = array(
       "{$field_name}[0][value]" => $value,
     );
-    $this->drupalPostForm("user/$uid/edit/$id/$profile_id", $edit, t('Save'));
+    $this->drupalPostForm("user/$uid/edit/profile/$id/$profile_id", $edit, t('Save'));
     $this->assertText(format_string('profile has been updated.'));
 
     // Verify that the own profile is still not visible on the account page.
@@ -148,7 +149,7 @@ class ProfileAccessTest extends WebTestBase {
     user_role_grant_permissions(DRUPAL_AUTHENTICATED_RID, array("delete own $id profile"));
 
     // Verify that the user can delete the own profile.
-    $this->drupalGet("user/$uid/edit/$id/$profile_id");
+    $this->drupalGet("user/$uid/edit/profile/$id/$profile_id");
     $this->clickLink(t('Delete'));
     $this->drupalPostForm(NULL, array(), t('Delete'));
     $this->assertRaw(format_string('@label profile deleted.', array('@label' => $this->type->label())));
@@ -158,7 +159,7 @@ class ProfileAccessTest extends WebTestBase {
     $this->drupalGet("user/$uid");
     $this->assertNoText($this->type->label());
     $this->assertNoText($value);
-    $this->drupalGet("user/$uid/edit/$id");
+    $this->drupalGet("user/$uid/edit/profile/$id");
     $this->assertNoText($value);
   }
 

--- a/src/Tests/ProfileAccessTest.php
+++ b/src/Tests/ProfileAccessTest.php
@@ -70,6 +70,7 @@ class ProfileAccessTest extends WebTestBase {
     $this->admin_user = $this->drupalCreateUser(array(
       'administer profile types',
       "view any $id profile",
+      "add any $id profile",
       "edit any $id profile",
       "delete any $id profile",
     ));

--- a/src/Tests/ProfileFieldAccessTest.php
+++ b/src/Tests/ProfileFieldAccessTest.php
@@ -39,6 +39,7 @@ class ProfileFieldAccessTest extends WebTestBase {
     ));
     $user_permissions = array(
       'access user profiles',
+      'add own personal profile',
       'edit own personal profile',
       'view any personal profile',
     );
@@ -77,6 +78,10 @@ class ProfileFieldAccessTest extends WebTestBase {
       'field_secret[0][value]' => $secret,
     );
     $this->drupalPostForm("user/$uid/edit/profile/$id", $edit, t('Save'));
+
+    // User cache page need to be cleared to see new profile.
+    // TODO: We shouldn't have to clear all cache to display this.
+    drupal_flush_all_caches();
 
     // Verify that the private field value appears for the profile owner.
     $this->drupalGet("user/$uid");

--- a/src/Tests/ProfileFieldAccessTest.php
+++ b/src/Tests/ProfileFieldAccessTest.php
@@ -76,7 +76,7 @@ class ProfileFieldAccessTest extends WebTestBase {
     $edit = array(
       'field_secret[0][value]' => $secret,
     );
-    $this->drupalPostForm("user/$uid/edit/$id", $edit, t('Save'));
+    $this->drupalPostForm("user/$uid/edit/profile/$id", $edit, t('Save'));
 
     // Verify that the private field value appears for the profile owner.
     $this->drupalGet("user/$uid");

--- a/src/Tests/ProfileTypeCRUDTest.php
+++ b/src/Tests/ProfileTypeCRUDTest.php
@@ -23,7 +23,7 @@ class ProfileTypeCRUDTest extends WebTestBase {
    * Tests CRUD operations for profile types through the UI.
    */
   function testCRUDUI() {
-    $this->drupalLogin($this->root_user);
+    $this->drupalLogin($this->rootUser);
 
     // Create a new profile type.
     $this->drupalGet('admin/config/people/profiles/types');


### PR DESCRIPTION
- Make module works since Drupal8 02d58f6 commit.
- In WebTestCase, root_user has been replaced by rootUser.
- Profile access check has been rebuild. It works more like entity_access and do not take care of URI anymore.
- Profile path should be /user/{user}/edit/profile/{profile_type} instead of /user/{user}/edit/{profile_type}. If we have another module, this could be painful. Maybe i'm wrong since we using symfony routing which can take care of which data type is placed in URL to route to the right controller.
