### PR TITLE
According to #2281645, Make entity annotations use link templates

### DIFF
--- a/src/Entity/Profile.php
+++ b/src/Entity/Profile.php
@@ -49,10 +49,10 @@ use Drupal\user\UserInterface;
  *     "uuid" = "uuid"
  *   },
  *  links = {
- *    "canonical" = "entity.profile.canonical",
- *    "admin-form" = "entity.profile_type.edit_form",
- *    "edit-form" = "entity.profile.edit_form",
- *    "delete-form" = "entity.profile.delete_form"
+ *    "canonical" = "/profile/{profile}",
+ *    "admin-form" = "/admin/config/people/profiles/types/manage/{profile_type}",
+ *    "edit-form" = "/user/{user}/edit/profile/{profile_type}/{profile}",
+ *    "delete-form" = "/profile/{profile}/delete"
  *   },
  * )
  */

--- a/src/Entity/ProfileType.php
+++ b/src/Entity/ProfileType.php
@@ -34,10 +34,10 @@ use Drupal\profile\ProfileTypeInterface;
  *     "label" = "label"
  *   },
  *   links = {
- *     "add-form" = "entity.profile_type.add_form",
- *     "delete-form" = "entity.profile_type.delete_form",
- *     "edit-form" = "entity.profile_type.edit_form",
- *     "admin-form" = "entity.profile_type.edit_form",
+ *     "add-form" = "/admin/config/people/profiles/types/add",
+ *     "delete-form" = "/admin/config/people/profiles/types/manage/{profile_type}/delete",
+ *     "edit-form" = "/admin/config/people/profiles/types/manage/{profile_type}",
+ *     "admin-form" = "/admin/config/people/profiles/types/manage/{profile_type}",
  *   }
  * )
  */


### PR DESCRIPTION
According to #2281645 Make entity annotations use link templates instead of route names.

Plus tests OK with drupal commit 1e985b0.
